### PR TITLE
Fix hover popup flicker for glossary highlights

### DIFF
--- a/content.js
+++ b/content.js
@@ -334,6 +334,17 @@ function ensureTempPopover() {
   if (PINNED_TEMP && document.body.contains(PINNED_TEMP)) return PINNED_TEMP;
   const pop = createEmptyPanel();
   pop.classList.add("ems-pop");
+  // Keep the temporary popover visible while hovered
+  pop.addEventListener("mouseenter", () => {
+    clearTimeout(HIDE_TIMER);
+  });
+  pop.addEventListener("mouseleave", () => {
+    clearTimeout(HIDE_TIMER);
+    HIDE_TIMER = setTimeout(() => {
+      pop.style.display = "none";
+      CURRENT_ANCHOR = null;
+    }, 160);
+  });
   document.body.appendChild(pop);
   PINNED_TEMP = pop;
   return pop;


### PR DESCRIPTION
## Summary
- keep temporary glossary popup visible while the mouse is over it to prevent flicker

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b40950f9a0832f9f139fe36bf11667